### PR TITLE
EO version was up to 0.29.4

### DIFF
--- a/.github/workflows/sandbox.yml
+++ b/.github/workflows/sandbox.yml
@@ -12,8 +12,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [windows-2022, ubuntu-20.04]
-        java: [11, 13]
+        os: [windows-2022, ubuntu-20.04, macos-12]
+        java: [11, 17]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-java@v3

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@ SOFTWARE.
   <artifactId>sandbox</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <eolang.version>0.28.11</eolang.version>
+    <eolang.version>0.29.4</eolang.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
   </properties>


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on updating the OS and Java versions in the sandbox.yml file and the eolang version in the pom.xml file.

### Detailed summary
- Added `macos-12` to the OS matrix in `.github/workflows/sandbox.yml`
- Updated the Java versions matrix in `.github/workflows/sandbox.yml` to include `17`
- Updated the `eolang.version` property in `pom.xml` from `0.28.11` to `0.29.4`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->